### PR TITLE
将实际负责的工作和类库分开，避免新的用户产生困扰。

### DIFF
--- a/Test/MyServices.cs
+++ b/Test/MyServices.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NewLife.Agent;
+using NewLife.Log;
+using NewLife.Threading;
+
+namespace Test
+{
+    public class MyServices:MyXService
+    {
+        private TimerX _timer;
+        protected override void StartWork(String reason)
+        {
+            // 5秒开始，每10秒执行一次
+            _timer = new TimerX(DoWork, null, 5_000, 10_000) { Async = true };
+        }
+
+
+        /// <summary>
+        /// 实际负责的工作
+        /// </summary>
+        /// <param name="state"></param>
+        private void DoWork(Object state)
+        {
+            string data = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+
+            //日志会输出到BinTest目录中
+            XTrace.WriteLine($"代码执行时间：{data}");
+        }
+    }
+}

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -9,7 +9,7 @@ namespace Test
         {
             Environment.SetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1");
 
-            var svc = new MyXService();
+            var svc = new MyServices();
             svc.Main(args);
         }
     }


### PR DESCRIPTION
我最开始使用这个项目的时候，就是不知道真正的工作负载写到哪里，看了TEST示例以后，发现有效的工作负载需要和类库写到一起，所以添加了这么一点改善。