### PR TITLE
在CreateDefaultBuilder之前设置Environment.CurrentDirectory

### DIFF
--- a/TestWorker/Program.cs
+++ b/TestWorker/Program.cs
@@ -1,6 +1,8 @@
 ﻿using NewLife.Extensions.Hosting.AgentService;
 using TestWorker;
 
+Environment.CurrentDirectory = ".".GetFullPath();
+
 var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>
     {


### PR DESCRIPTION
避免ContentRoot被设置为C:\Windows\system32