### PR TITLE
[fix] 修护使用aspnetmvc项目时Ubuntu直接调用systemctl stop xxx  无法优雅退出服务，需要超时等待

### DIFF
--- a/NewLife.Agent/Systemd.cs
+++ b/NewLife.Agent/Systemd.cs
@@ -165,6 +165,8 @@ public class Systemd : Host
         sb.AppendLine("Restart=on-failure");
         //sb.AppendLine("RestartSec=1");
 
+        sb.AppendLine("KillSignal=SIGINT");
+
         sb.AppendLine();
         sb.AppendLine("[Install]");
         sb.AppendLine("WantedBy=multi-user.target");

--- a/NewLife.Agent/Systemd.cs
+++ b/NewLife.Agent/Systemd.cs
@@ -148,6 +148,7 @@ public class Systemd : Host
         var sb = new StringBuilder();
         sb.AppendLine("[Unit]");
         sb.AppendLine($"Description={des}");
+        sb.AppendLine($"After=network.target");
         //sb.AppendLine("StartLimitIntervalSec=0");
 
         sb.AppendLine();
@@ -162,8 +163,13 @@ public class Systemd : Host
         // no 表示服务退出时，服务不会自动重启，默认值。
         // on-failure 表示当进程以非零退出代码退出，由信号终止；当操作(如服务重新加载)超时；以及何时触发配置的监视程序超时时，服务会自动重启。
         // always 表示只要服务退出，则服务将自动重启。
-        sb.AppendLine("Restart=on-failure");
-        //sb.AppendLine("RestartSec=1");
+        sb.AppendLine("Restart=always");
+
+        // RestartSec 重启间隔，比如某次异常后，等待3(s)再进行启动，默认值0.1(s)
+        sb.AppendLine("RestartSec=3");
+
+        // StartLimitInterval: 无限次重启，默认是10秒内如果重启超过5次则不再重启，设置为0表示不限次数重启
+        sb.AppendLine("StartLimitInterval=0");
 
         sb.AppendLine("KillSignal=SIGINT");
 


### PR DESCRIPTION
你好！最近集成Agent项目作为跨平台服务安装卸载操作，一直有个问题困扰我，就是通过LInux系统调用systemctl stop无法优雅退出，需要等等大概30s到超时才能正常退出，期间我也尝试找代码原因如何规避，一直无法很好解决。今天突然尝试调整生成的systemd service文件在区段[Service]中增加 KillSignal=SIGINT 这可发送及时信号进行退出，是否可以直接调整代码增加该行？
`[Unit]
Description=IDB serivce

[Service]
Type=simple
ExecStart=/test/ws/main_svc/Test.MainWS.Web -s
WorkingDirectory=/test/ws/main_svc
Restart=on-failure
KillSignal=SIGINT

[Install]
WantedBy=multi-user.target
`