### PR TITLE
修改RcInit运行程序时,针对某些Linux内核，启动必须Sxx开头的服务文件,故创建一个S开头的软链接文件进行启动

### DIFF
--- a/NewLife.Agent/RcInit.cs
+++ b/NewLife.Agent/RcInit.cs
@@ -133,6 +133,9 @@ public class RcInit : Host
         // 给予可执行权限
         Process.Start("chmod", $"+x {file}");
 
+        // 创建同级链接文件 [解决某些linux启动必须以Sxx开头的启动文件]
+        Process.Start("ln", $"-s {systemdPath}/{serviceName} {systemdPath}/S50{serviceName}");
+
         // 创建链接文件
         for (var i = 0; i < 7; i++)
         {
@@ -157,6 +160,10 @@ public class RcInit : Host
         XTrace.WriteLine("{0}.Remove {1}", GetType().Name, serviceName);
 
         var file = _path.CombinePath($"{serviceName}");
+        if (File.Exists(file)) File.Delete(file);
+
+        // 删除同级链接文件
+        file = _path.CombinePath($"S50{serviceName}");
         if (File.Exists(file)) File.Delete(file);
 
         // 删除链接文件


### PR DESCRIPTION
目前公司两个硬件的Linux内核Linux 5.4.61-rt37 #21 SMP PREEMPT；发现系统启动必须是Sxx开头的服务文件，故提出如上解决方案