### PR TITLE
修复当星尘代理路径中有空格时在windowns8.x以及windows server2012下注册服务时失败的问题

### DIFF
--- a/NewLife.Agent/ServiceBase.cs
+++ b/NewLife.Agent/ServiceBase.cs
@@ -617,10 +617,11 @@ public abstract class ServiceBase : DisposeBase
         if (args.Length >= 1)
         {
             var fileName = Path.GetFileName(exe);
+            exe = $"\"{exe}\"";
             if (fileName.EqualIgnoreCase("dotnet", "dotnet.exe"))
-                exe += " " + args[0].GetFullPath();
+                exe += " " + $"\"{args[0].GetFullPath()}\"";
             else if (fileName.EqualIgnoreCase("mono", "mono.exe", "mono-sgen"))
-                exe = args[0].GetFullPath();
+                exe = $"\"{args[0].GetFullPath()}\"";
         }
 
         //var arg = UseAutorun ? "-run" : "-s";
@@ -636,7 +637,7 @@ public abstract class ServiceBase : DisposeBase
                 if (args[i].EqualIgnoreCase("-server", "-user", "-group"))
                     i++;
                 else
-                    list.Add(args[i]);
+                    list.Add($"\"{args[i]}\"");
             }
             if (list.Count > 0) arg += " " + list.Join(" ");
         }


### PR DESCRIPTION
问题：
在windows8.x和 windows server 2012下，当星尘代理所在路径中有空格时，服务可以注册成功但无法启动

修复前：

![space_error](https://github.com/NewLifeX/NewLife.Agent/assets/5615543/c9518f8f-77b0-4d42-ba8c-f80b14a90c14)
![space1](https://github.com/NewLifeX/NewLife.Agent/assets/5615543/9a7fd5bf-3112-4416-868e-4dc1f25400f4)

修复后：

![space](https://github.com/NewLifeX/NewLife.Agent/assets/5615543/1f412eaa-04b8-4726-a412-5a9c7fa77f2b)
